### PR TITLE
Disable usdhc1

### DIFF
--- a/arch/arm64/boot/dts/system-electronics/imx8mp-astrial.dts
+++ b/arch/arm64/boot/dts/system-electronics/imx8mp-astrial.dts
@@ -592,7 +592,7 @@
 	bus-width = <4>;
 	broken-cd;
 	no-1-8-v;
-	status = "okay";
+	status = "disabled";
 };
 
 &usdhc2 {


### PR DESCRIPTION
USDHC1 has been disabled by default since it might not be present and its GPIOs might be used for other purposes (e.g. CM4-POE BOARD and CM4-ETH-RS485-BASE-B with a buzzer)